### PR TITLE
cabal: depend on network-uri rather than network

### DIFF
--- a/snap-app.cabal
+++ b/snap-app.cabal
@@ -21,7 +21,7 @@ library
   other-modules:     Control.Monad.Catch
   build-depends:     base >= 4 && <5,
                      snap-core,
-                     network,
+                     network-uri,
                      postgresql-simple,
                      mtl,
                      blaze-html >= 0.6,


### PR DESCRIPTION
% ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.8.3

Before:
    % cabal -j install
    Warning: The package list for 'hackage.haskell.org' is 34 days old.
    Run 'cabal update' to get the latest list of available packages.
    Resolving dependencies...
    In order, the following will be installed:
    snap-app-0.6.0 (reinstall) changes: network-2.6.0.2 added, network-uri-2.6.0.1
    removed
    Warning: Note that reinstalls are always dangerous. Continuing anyway...
    Notice: installing into a sandbox located at
    /home/jchee/packages/snap-app/.cabal-sandbox
    Configuring snap-app-0.6.0...
    Building snap-app-0.6.0...
    Failed to install snap-app-0.6.0
    Build log ( /home/jchee/packages/snap-app/.cabal-sandbox/logs/snap-app-0.6.0.log ):
    Configuring snap-app-0.6.0...
    Building snap-app-0.6.0...
    Preprocessing library snap-app-0.6.0...

```
src/Snap/App/Controller.hs:31:8:
    Could not find module ‘Network.URI’
    It is a member of the hidden package ‘network-uri-2.6.0.1’.
    Perhaps you need to add ‘network-uri’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
cabal: Error: some packages failed to install:
snap-app-0.6.0 failed during the building phase. The exception was:
ExitFailure 1
```

After:
    % cabal -j install
    Warning: The package list for 'hackage.haskell.org' is 34 days old.
    Run 'cabal update' to get the latest list of available packages.
    Resolving dependencies...
    In order, the following will be installed:
    snap-app-0.6.0 (reinstall)
    Warning: Note that reinstalls are always dangerous. Continuing anyway...
    Notice: installing into a sandbox located at
    /home/jchee/packages/snap-app/.cabal-sandbox
    Configuring snap-app-0.6.0...
    Building snap-app-0.6.0...
    Installed snap-app-0.6.0

Also tested install with a clean sandbox.
